### PR TITLE
Adding dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM ubuntu:12.04
+
+RUN apt-get update && apt-get install -y apache2 && apt-get clean && apt-get autoremove
+
+ENV APACHE_RUN_USER www-data
+ENV APACHE_RUN_GROUP www-data
+ENV APACHE_LOG_DIR /var/log/apache2
+
+RUN rm /var/www/index.html
+ADD index.html /var/www/index.html
+
+EXPOSE 80
+
+ENTRYPOINT ["/usr/sbin/apache2", "-D", "FOREGROUND"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM ubuntu:12.04
 
-RUN apt-get update && apt-get install -y apache2 && apt-get clean && apt-get autoremove
+RUN apt-get update && apt-get install -y apache2 \
+&& apt-get clean \
+&& apt-get autoremove
 
 ENV APACHE_RUN_USER www-data
 ENV APACHE_RUN_GROUP www-data

--- a/index.html
+++ b/index.html
@@ -1,0 +1,1 @@
+<b>Hello World</b>


### PR DESCRIPTION
This is to address https://github.com/virgo-agent-toolkit/agent-poller-noit-parity/issues/3

Adding a dockerfile and a sample index.html for testing.

If you are on Linux you can skip the VM part.

Steps to follow (If you are on Mac):

Install: https://github.com/boot2docker/boot2docker-cli/releases/tag/v0.11.1-pre1

export DOCKER_HOST=tcp://127.0.0.1:4243

boot2docker up

docker build .

boot2docker ip

docker run -p 80:80 [hash] , here the hash is the hash you get from the docker build step

Hit http://the_ip_you_got_from_the_boot2docker_ip_step
