### PR TITLE
noit submodule should be under deps/ dir

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "deps"]
-	path = deps
+	path = deps/noit
 	url = https://github.com/circonus-labs/reconnoiter.git


### PR DESCRIPTION
I noticed the noit submodule was named `deps`. Moved it under a `deps/` dir. Submodules are confusing but I think I did this right.
