### PR TITLE
Add init script

### DIFF
--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -1,8 +1,0 @@
-[supervisord]
-nodaemon=true
-
-[program:noit]
-command=/usr/local/sbin/noitd -c noitconf/noit.conf
-
-[program:stratcon]
-command=/usr/local/sbin/stratcond -c noitconf/stratcon.conf

--- a/deps/Dockerfile
+++ b/deps/Dockerfile
@@ -4,20 +4,20 @@ RUN apt-get update && \
  apt-get install -y autoconf build-essential \
  zlib1g-dev uuid-dev libpcre3-dev libssl-dev libpq-dev libxslt-dev \
  libapr1-dev libaprutil1-dev xsltproc libncurses5-dev python \
- libssh2-1-dev libsnmp-dev openjdk-6-jdk libprotobuf-c0-dev uuid-runtime telnet vim git lsof supervisor
+ libssh2-1-dev libsnmp-dev openjdk-6-jdk libprotobuf-c0-dev uuid-runtime telnet vim git lsof
 
 
-ADD deps/noit /opt/noit
+ADD noit /opt/noit
 ADD conf /noitconf
-ADD conf/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 RUN mkdir "/var/log/noitd.feed(stratcon)"
-RUN mkdir -p /var/log/supervisor
 
 RUN cd /opt/noit && autoconf && export LDFLAGS="-ldl -lm" && ./configure && make && make install
 
 RUN cp /usr/local/etc/config_templates.conf /noitconf/config_templates.conf
 
 RUN cd  /opt/noit/test && cp test-*.crt test-*.key /usr/local/etc/
+
+ADD noitstratconinit.bash noitstratconinit.bash
 RUN uuidgen
 
 
@@ -25,4 +25,4 @@ RUN apt-get clean
 
 EXPOSE 32322 43191 8888 80
 
-CMD ["/usr/bin/supervisord" ,"-c", "/etc/supervisor/conf.d/supervisord.conf"]
+CMD /bin/bash noitstratconinit.bash && tail -f /var/log/noitd.feed/00000000

--- a/deps/conf/noit.conf
+++ b/deps/conf/noit.conf
@@ -1,0 +1,205 @@
+<?xml version="1.0" encoding="utf8" standalone="yes"?>
+<noit lockfile="/var/run/noitd.lock" text_size_limit="512">
+  <!-- <watchdog glider="/opt/gimli/bin/glider" tracedir="/var/log/noitd.crash"/> -->
+  <eventer>
+    <config>
+      <default_queue_threads>10</default_queue_threads>
+      <default_ca_chain>/usr/local/etc/default-ca-chain.crt</default_ca_chain>
+      <ssl_dhparam512_file>/usr/local/etc/dhparam512.txt</ssl_dhparam512_file>
+      <ssl_dhparam1024_file>/usr/local/etc/dhparam1024.txt</ssl_dhparam1024_file>
+    </config>
+  </eventer>
+  <logs>
+    <log name="internal" type="memory" path="10000,100000"/>
+    <console_output>
+      <outlet name="stderr"/>
+      <outlet name="internal"/>
+      <log name="error"/>
+      <log name="debug" disabled="true"/>
+    </console_output>
+    <feeds>
+      <log name="feed" type="jlog" path="/var/log/noitd.feed(stratcon)"/>
+    </feeds>
+    <components>
+      <error>
+        <outlet name="error"/>
+        <log name="error/collectd"/>
+        <log name="error/ganglia"/>
+        <log name="error/dns"/>
+        <log name="error/eventer"/>
+        <log name="error/external"/>
+        <log name="error/lua"/>
+        <log name="error/mysql"/>
+        <log name="error/ping_icmp"/>
+        <log name="error/postgres"/>
+        <log name="error/selfcheck"/>
+        <log name="error/snmp"/>
+        <log name="error/ssh2"/>
+        <log name="error/statsd"/>
+      </error>
+      <debug>
+        <outlet name="debug"/>
+        <log name="debug/collectd" disabled="true"/>
+        <log name="debug/ganglia" disabled="true"/>
+        <log name="debug/dns" disabled="true"/>
+        <log name="debug/eventer" disabled="true"/>
+        <log name="debug/external" disabled="true"/>
+        <log name="debug/lua" disabled="true"/>
+        <log name="debug/mysql" disabled="true"/>
+        <log name="debug/ping_icmp" disabled="true"/>
+        <log name="debug/postgres" disabled="true"/>
+        <log name="debug/selfcheck" disabled="true"/>
+        <log name="debug/snmp" disabled="true"/>
+        <log name="debug/ssh2" disabled="true"/>
+        <log name="debug/statsd" disabled="true"/>
+      </debug>
+    </components>
+    <feeds>
+      <config><extended_id>off</extended_id></config>
+      <outlet name="feed"/>
+      <log name="check"/>
+      <log name="delete"/>
+      <log name="status"/>
+      <log name="metrics"/>
+      <log name="bundle"/>
+      <log name="config"/>
+    </feeds>
+  </logs>
+  <modules directory="/usr/local/libexec/noit">
+    <loader image="lua" name="lua">
+      <config><directory>/usr/local/libexec/noit/?.lua</directory></config>
+    </loader>
+    <module image="selfcheck" name="selfcheck"/>
+    <module image="ping_icmp" name="ping_icmp"/>
+    <module image="dns" name="dns"/>
+    <module image="ssh2" name="ssh2"/>
+    <module image="httptrap" name="httptrap"/>
+    <module image="statsd" name="statsd"/>
+    <module image="ganglia" name="ganglia"/>
+    <module loader="lua" name="varnish" object="noit.module.varnish"/>
+    <module loader="lua" name="http" object="noit.module.http"/>
+    <module loader="lua" name="resmon" object="noit.module.resmon"/>
+    <module loader="lua" name="smtp" object="noit.module.smtp"/>
+    <module loader="lua" name="ntp" object="noit.module.ntp"/>
+    <module loader="lua" name="dhcp" object="noit.module.dhcp"/>
+    <module loader="lua" name="pop3" object="noit.module.pop3"/>
+    <module loader="lua" name="monit" object="noit.module.monit"/>
+    <jezebel>
+      <config><url>http://127.0.0.1:8083/dispatch</url></config>
+      <module loader="lua" name="jmx" object="noit.module.jezebel"/>
+      <module loader="lua" name="snmp" object="noit.module.jezebel"/>
+    </jezebel>
+    <generic image="check_test" name="check_test"/>
+    <generic image="lua" name="lua_web">
+      <config>
+        <directory>/usr/local/libexec/noit/?.lua</directory>
+        <dispatch>web</dispatch>
+      </config>
+    </generic>
+    <generic image="ip_acl" name="ip_acl"/>
+  </modules>
+  <listeners>
+    <sslconfig>
+      <optional_no_ca>true</optional_no_ca>
+      <certificate_file>/usr/local/etc/test-noit.crt</certificate_file>
+      <key_file>/usr/local/etc/test-noit.key</key_file>
+      <ca_chain>/usr/local/etc/test-ca.crt</ca_chain>
+    </sslconfig>
+    <consoles type="noit_console">
+      <listener address="/tmp/noit">
+        <config>
+          <line_protocol>telnet</line_protocol>
+        </config>
+      </listener>
+      <listener address="*" port="32322">
+        <config>
+          <line_protocol>telnet</line_protocol>
+        </config>
+      </listener>
+      <listener address="*" port="32323" ssl="on"/>
+    </consoles>
+    <listener type="control_dispatch" address="*" port="43191" ssl="on">
+      <config>
+        <log_transit_feed_name>feed</log_transit_feed_name>
+        <document_root>/usr/local/share/noit-web</document_root>
+      </config>
+    </listener>
+    <listener type="http_rest_api" address="*" port="8888" ssl="on">
+      <config>
+        <document_root>/usr/local/share/noit-web</document_root>
+      </config>
+    </listener>
+  </listeners>
+  <rest>
+    <acl>
+      <rule type="allow" />
+    </acl>
+  </rest>
+  <checks filterset="default"
+          resolve_rtype="prefer-ipv4"
+          transient_min_period="1000" transient_period_granularity="500">
+    <config xmlns:ip_acl="noit://module/ip_acl">
+      <ip_acl:global/>
+    </config>
+    <check uuid="f7cea020-f19d-11dd-85a6-cb6d3a2207dc" module="selfcheck" target="127.0.0.1" period="5000" timeout="4000"/>
+    <check uuid="1b4e28ba-2fa1-11d2-883f-b9b761bde3fb" module="ping_icmp" target="8.8.8.8" period="15000" timeout="14000"/>
+    <check uuid="9bccffcf-fee8-4885-987a-faa10f16e724" module="ganglia" target="127.0.0.1" period="15000" timeout="14000"/>
+    <dc1 timeout="30000" period="60000" transient_min_period="10000">
+      <icmp module="ping_icmp">
+        <check uuid="1b4e28ba-2fa1-11d2-883f-b9a761bde3fb" target="66.225.209.7"/>
+      </icmp>
+      <web module="http">
+        <config xmlns:ip_acl="noit://module/ip_acl">
+          <ip_acl:sample/>
+        </config>
+        <check uuid="1b4e28ba-2fa1-11d2-883f-b9a761bde3aa" target="labs.omniti.com">
+          <config>
+            <url>https://labs.omniti.com/</url>
+            <code>200</code>
+          </config>
+        </check>
+        <check uuid="1b4e28ba-2fa1-11d2-883f-b9a761bde3ff" target="taskman.omniti.com">
+          <config>
+            <url>https://taskman.omniti.com/</url>
+            <code>200</code>
+          </config>
+        </check>
+      </web>
+      <resmon module="resmon" period="30000">
+        <check uuid="1b4e28ba-2fa1-11d2-883f-b9a761bde3fd" timeout="2000" target="10.225.209.36"/>
+      </resmon>
+      <switches module="snmp" period="60000">
+        <config inherit="SwitchPortX"/>
+        <switch target="10.1.2.3">
+          <check uuid="1b4e28ba-2fa1-11d2-883f-e9b761bde3fb" name="switchport::1"/>
+          <check uuid="1b4e28ba-3fa1-11d2-883f-e9b761bde3fb" name="switchport::2"/>
+          <check uuid="1b4e29ba-3fa1-11d2-883f-e9b761bde3fb" name="switchport::3"/>
+          <check uuid="4deb0724-ccee-4360-83bc-255e7b9d989d" name="switchport::4"/>
+        </switch>
+      </switches>
+      <disk module="snmp" period="60000">
+        <config inherit="disk"><community>test</community></config>
+        <check target="127.0.0.1" uuid="16eb9194-cbf4-11de-8fba-031dd96e4057" name="disk::1" />
+      </disk>
+    </dc1>
+    <check uuid="002d58ff-20ff-4db0-9420-782fc1748dc4" module="ssh2" target="git.github.com" period="60000" timeout="4000"/>
+    <check uuid="ff4f1de8-a405-11e1-8770-9347de0fce85" module="statsd" target="127.0.0.1" period="60000" timeout="59999"/>
+  </checks>
+  <filtersets>
+    <filterset name="default">
+      <rule type="deny" module="^ping_icmp$" metric="^(?:minimum|maximum|count)$" />
+      <rule type="allow"/>
+    </filterset>
+  </filtersets>
+  <config_templates>
+    <include file="/noitconf/config_templates.conf"/>
+  </config_templates>
+  <acls>
+    <acl name="global">
+      <rule type="deny">8.8.38.0/24</rule>
+    </acl>
+    <acl name="sample">
+      <rule type="deny">66.225.209.0/24</rule>
+    </acl>
+  </acls>
+</noit>

--- a/deps/conf/pg_hba.conf
+++ b/deps/conf/pg_hba.conf
@@ -1,0 +1,99 @@
+# PostgreSQL Client Authentication Configuration File
+# ===================================================
+#
+# Refer to the "Client Authentication" section in the PostgreSQL
+# documentation for a complete description of this file.  A short
+# synopsis follows.
+#
+# This file controls: which hosts are allowed to connect, how clients
+# are authenticated, which PostgreSQL user names they can use, which
+# databases they can access.  Records take one of these forms:
+#
+# local      DATABASE  USER  METHOD  [OPTIONS]
+# host       DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+# hostssl    DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+# hostnossl  DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+#
+# (The uppercase items must be replaced by actual values.)
+#
+# The first field is the connection type: "local" is a Unix-domain
+# socket, "host" is either a plain or SSL-encrypted TCP/IP socket,
+# "hostssl" is an SSL-encrypted TCP/IP socket, and "hostnossl" is a
+# plain TCP/IP socket.
+#
+# DATABASE can be "all", "sameuser", "samerole", "replication", a
+# database name, or a comma-separated list thereof. The "all"
+# keyword does not match "replication". Access to replication
+# must be enabled in a separate record (see example below).
+#
+# USER can be "all", a user name, a group name prefixed with "+", or a
+# comma-separated list thereof.  In both the DATABASE and USER fields
+# you can also write a file name prefixed with "@" to include names
+# from a separate file.
+#
+# ADDRESS specifies the set of hosts the record matches.  It can be a
+# host name, or it is made up of an IP address and a CIDR mask that is
+# an integer (between 0 and 32 (IPv4) or 128 (IPv6) inclusive) that
+# specifies the number of significant bits in the mask.  A host name
+# that starts with a dot (.) matches a suffix of the actual host name.
+# Alternatively, you can write an IP address and netmask in separate
+# columns to specify the set of hosts.  Instead of a CIDR-address, you
+# can write "samehost" to match any of the server's own IP addresses,
+# or "samenet" to match any address in any subnet that the server is
+# directly connected to.
+#
+# METHOD can be "trust", "reject", "md5", "password", "gss", "sspi",
+# "krb5", "ident", "peer", "pam", "ldap", "radius" or "cert".  Note that
+# "password" sends passwords in clear text; "md5" is preferred since
+# it sends encrypted passwords.
+#
+# OPTIONS are a set of options for the authentication in the format
+# NAME=VALUE.  The available options depend on the different
+# authentication methods -- refer to the "Client Authentication"
+# section in the documentation for a list of which options are
+# available for which authentication methods.
+#
+# Database and user names containing spaces, commas, quotes and other
+# special characters must be quoted.  Quoting one of the keywords
+# "all", "sameuser", "samerole" or "replication" makes the name lose
+# its special character, and just match a database or username with
+# that name.
+#
+# This file is read on server startup and when the postmaster receives
+# a SIGHUP signal.  If you edit the file on a running system, you have
+# to SIGHUP the postmaster for the changes to take effect.  You can
+# use "pg_ctl reload" to do that.
+
+# Put your actual configuration here
+# ----------------------------------
+#
+# If you want to allow non-local connections, you need to add more
+# "host" records.  In that case you will also need to make PostgreSQL
+# listen on a non-local interface via the listen_addresses
+# configuration parameter, or via the -i or -h command line switches.
+
+
+
+
+# DO NOT DISABLE!
+# If you change this first entry you will need to make sure that the
+# database superuser can access the database using some other method.
+# Noninteractive access to all databases is required during automatic
+# maintenance (custom daily cronjobs, replication, and similar tasks).
+#
+# Database administrative login by Unix domain socket
+local   all             postgres                                trust
+
+# TYPE  DATABASE        USER            ADDRESS                 METHOD
+
+# "local" is for Unix domain socket connections only
+local   all             all                                     trust
+# IPv4 local connections:
+host    all             all             127.0.0.1/32            md5
+# IPv6 local connections:
+host    all             all             ::1/128                 md5
+# Allow replication connections from localhost, by a user with the
+# replication privilege.
+#local   replication     postgres                                peer
+#host    replication     postgres        127.0.0.1/32            md5
+#host    replication     postgres        ::1/128                 md5

--- a/deps/conf/stratcon.conf
+++ b/deps/conf/stratcon.conf
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="utf8" standalone="yes"?>
+<stratcon lockfile="/var/run/stratcond.lock">
+  <!-- <watchdog glider="/opt/gimli/bin/glider" tracedir="/var/log/stratcond.crash"/> -->
+  <eventer/>
+
+  <logs>
+    <console_output>
+      <outlet name="stderr"/>
+      <log name="error"/>
+      <log name="debug"/>
+      <log name="error/iep"/>
+      <log name="error/eventer" disabled="true"/>
+      <log name="error/datastore" disabled="true"/>
+      <log name="debug/eventer" disabled="true"/>
+    </console_output>
+  </logs>
+
+  <modules directory="/usr/local/libexec/noit">
+    <generic image="stomp_driver" name="stomp_driver"/>
+    <generic image="postgres_ingestor" name="postgres_ingestor"/>
+    <generic image="handoff_ingestor" name="handoff_ingestor"/>
+  </modules>
+
+  <noits>
+    <config>
+      <!--
+        If we have a connection failure, attempt to reconnect
+        immediately.  Upon failure wait 1000ms (1s) and
+        exponentially backoff up to 900000ms (900s or 15m)
+      -->
+      <reconnect_initial_interval>1000</reconnect_initial_interval>
+      <reconnect_maximum_interval>15000</reconnect_maximum_interval>
+    </config>
+    <sslconfig>
+      <key_file>/usr/local/etc/test-stratcon.key</key_file>
+      <certificate_file>/usr/local/etc/test-stratcon.crt</certificate_file>
+      <ca_chain>/usr/local/etc/test-ca.crt</ca_chain>
+    </sslconfig>
+    <noit address="127.0.0.1" port="43191" />
+  </noits>
+
+  <iep disabled="true">
+    <start directory="/usr/local/var/db/noit-iep"
+           command="/usr/local/bin/run-iep.sh" />
+    <broker adapter="rabbitmq">
+      <hostname>mq1,mq2</hostname>
+      <username>guest</username>
+      <password>guest</password>
+    </broker>
+    <mq type="rabbitmq">
+      <hostname>mq1,mq2</hostname>
+      <exchange>noit.firehose</exchange>
+      <exchangetype>topic</exchangetype>
+      <routingkey>check,null</routingkey>
+      <username>guest</username>
+      <password>guest</password>
+    </mq>
+    <riemann>
+      <configfile>riemann.config</configfile>
+    </riemann>
+  </iep>
+
+  <database>
+    <journal>
+      <path>/var/log/stratcon.persist</path>
+    </journal>
+    <dbconfig>
+      <host>postgres</host>
+      <dbname>reconnoiter</dbname>
+      <user>stratcon</user>
+      <password>stratcon</password>
+    </dbconfig>
+    <statements>
+      <!-- These are optional and used for stuff like setting search paths -->
+      <!--
+      <metanodepostconnect><![CDATA[
+        SELECT do_some_magic();
+      ]]></metanodepostconnect>
+      <storagepostconnect><![CDATA[
+        SELECT do_some_magic($1,$2);
+      ]]></storagepostconnect>
+      -->
+      <allchecks><![CDATA[
+        SELECT remote_address, id, target, module, name
+          FROM check_currently
+      ]]></allchecks>
+      <findcheck><![CDATA[
+        SELECT remote_address, id, target, module, name
+          FROM check_currently
+         WHERE sid = $1
+      ]]></findcheck>
+      <allstoragenodes><![CDATA[
+        SELECT storage_node_id, fqdn, dsn
+          FROM stratcon.storage_node
+      ]]></allstoragenodes>
+      <findstoragenode><![CDATA[
+        SELECT fqdn, dsn
+          FROM stratcon.storage_node
+         WHERE storage_node_id = $1
+      ]]></findstoragenode>
+      <mapallchecks><![CDATA[
+        SELECT id, sid, noit as remote_cn, storage_node_id, fqdn, dsn
+          FROM stratcon.map_uuid_to_sid LEFT JOIN stratcon.storage_node USING (storage_node_id)
+      ]]></mapallchecks>
+      <mapchecktostoragenode><![CDATA[
+        SELECT o_storage_node_id as storage_node_id, o_sid as sid,
+               o_fqdn as fqdn, o_dsn as dsn, o_noit as remote_cn
+          FROM stratcon.map_uuid_to_sid($1,$2)
+      ]]></mapchecktostoragenode>
+      <check><![CDATA[
+        INSERT INTO check_archive_%Y%m%d
+                    (remote_address, whence, sid, id, target, module, name)
+             VALUES ($1, 'epoch'::timestamptz + ($2 || ' seconds')::interval,
+                     $3, $4, $5, $6, $7)
+      ]]></check>
+      <status><![CDATA[
+        INSERT INTO check_status_archive_%Y%m%d
+                    (whence, sid, state, availability, duration, status)
+             VALUES ('epoch'::timestamptz + ($1 || ' seconds')::interval,
+                     $2, $3, $4, $5, $6)
+      ]]></status>
+      <metric_numeric><![CDATA[
+        INSERT INTO metric_numeric_archive_%Y%m%d
+                    (whence, sid, name, value)
+             VALUES ('epoch'::timestamptz + ($1 || ' seconds')::interval,
+                     $2, $3, $4)
+      ]]></metric_numeric>
+      <metric_text><![CDATA[
+        INSERT INTO metric_text_archive_%Y%m%d
+                    ( whence, sid, name,value)
+             VALUES ('epoch'::timestamptz + ($1 || ' seconds')::interval,
+                     $2, $3, $4)
+      ]]></metric_text>
+      <config><![CDATA[
+        SELECT stratcon.update_config
+               ($1, $2, $3,
+                'epoch'::timestamptz + ($4 || ' seconds')::interval,
+                $5)
+      ]]></config>
+      <findconfig><![CDATA[
+        SELECT config FROM stratcon.current_node_config WHERE remote_cn = $1
+      ]]></findconfig>
+    </statements>
+  </database>
+
+  <listeners>
+    <sslconfig>
+      <key_file>/usr/local/etc/test-stratcon.key</key_file>
+      <certificate_file>/usr/local/etc/test-stratcon.crt</certificate_file>
+      <ca_chain>/usr/local/etc/test-ca.crt</ca_chain>
+    </sslconfig>
+    <consoles type="noit_console">
+      <listener address="/tmp/stratcon">
+        <config><line_protocol>telnet</line_protocol></config>
+      </listener>
+    </consoles>
+    <realtime type="http_rest_api">
+      <listener address="*" port="80">
+        <config>
+          <hostname>stratcon.noit.example.com</hostname>
+          <document_domain>noit.example.com</document_domain>
+        </config>
+      </listener>
+    </realtime>
+    <listener type="control_dispatch" address="*" port="43191" ssl="on" />
+  </listeners>
+
+  <rest>
+    <acl type="deny">
+      <rule type="deny" url="/\.svn"/>
+      <rule type="allow" cn="^admin$"/>
+      <rule type="allow" cn="^nagios$" url="^/noits/show$"/>
+      <rule type="allow" url="^/noits/config$"/>
+      <rule type="allow" url="/handoff/journals"/>
+      <rule type="allow" url="^/data/"/>
+      <rule type="allow" url="^/$"/>
+    </acl>
+  </rest>
+
+</stratcon>

--- a/deps/noitstratconinit.bash
+++ b/deps/noitstratconinit.bash
@@ -1,0 +1,4 @@
+#!/bin/bash
+/usr/local/sbin/noitd -c noitconf/noit.conf
+sleep 10
+/usr/local/sbin/stratcond -c noitconf/stratcon.conf


### PR DESCRIPTION
Why: 

While using supervisord the noit and stratcon processes were being started pretty much simultaneously which made a curl http://noit/handoff/journals -k -v from a remote container not receive any journals.

Solution: 
A bash script with a small sleep between the 2 processes. 

Workaround:
The issue with using a shell script with Docker is that as soon as the script is done executing the container exits. Even running with a -d flag does not help as the entry point itself exits.
running with -t -i  /bin/bash does not start the processes in the container.

So added a
CMD /bin/bash noitstratconinit.bash && tail -f /var/log/noitd.feed/00000000 and ran container with -d flag.

To test this out 

docker run -i -t  -P --name postgres -d nachiket/postgres
docker run --name apache_borrowed -p 80:80 -p 443:443 -d eboraas/apache
docker run -d -p 32322:32322 -p 43191:43191 -p 8888:8888 -p 80:80 -ti --link postgres:postgres --link apache_borrowed:apache --name noit nachiket/noit

If you are on mac
curl http://192.168.59.103/handoff/journals (make sure you boot2docker ip is actually 192.168.59.103 )

If you are on any Linux based OS
curl http://localhost/handoff/journals

Note: You will start seeing the journals in about 3 to 5 sec after the hello message.
